### PR TITLE
Fixes #5 - Update streaming strategy to point to the derivatives filestore instead of Fedora.

### DIFF
--- a/src/java/edu/ucsd/library/dams/util/EncryptedStreamNameModule.java
+++ b/src/java/edu/ucsd/library/dams/util/EncryptedStreamNameModule.java
@@ -207,7 +207,7 @@ public class EncryptedStreamNameModule extends ModuleBase
 	 * @param streamName Encrypted stream name in the format:
      *     [type:] [nonce] "," [encrypted stream info]
 	 *   The encrypted stream info should be in the format:
-	 *     [object id] " " [fileset id] " " [binary file name] " " [file id] " " [request IP] 
+	 *     [object id] " " [fileset id] " " [file id] " " [request IP] 
 	 * @param requestIP The IP address of the Wowza request, which will be
 	 *   checked against the IP address in the stream info package.
 	**/
@@ -235,15 +235,14 @@ public class EncryptedStreamNameModule extends ModuleBase
 
 		String objid = argArr[0];
 		String filesetid = argArr[1];
-		String binaryname = argArr[2];
-		String fileid = argArr[3];
-		String ip = argArr[4];
+		String fileid = argArr[2];
+		String ip = argArr[3];
 
 		// check format of objid and fileid
 		if ( objid == null || objid.trim().equals("")
-			|| filesetid == null || filesetid.trim().equals("") || binaryname == null || binaryname.trim().equals("") )
+			|| filesetid == null || filesetid.trim().equals("") || fileid == null || fileid.trim().equals("") )
 		{
-			throw new Exception( "Invalid object:... " + objid + ":" + filesetid + ":" +  binaryname);
+			throw new Exception( "Invalid object:... " + objid + ":" + filesetid + ":" +  fileid);
 		}
 
 		// make sure the request IP matches the verified IP
@@ -283,13 +282,13 @@ public class EncryptedStreamNameModule extends ModuleBase
 		try
 		{
 			// pairpath based on objid
-			int depth = 3;
-			for( int i = 0; i < (binaryname.length() - 1) && i < depth * 2; i += 2 )
+			int depth = 4;
+			for( int i = 0; i < (filesetid.length() - 1) && i < depth * 2; i += 2 )
 			{
-				newName += binaryname.substring(i,i+2);
+				newName += filesetid.substring(i,i+2);
 				newName += "/";
 			}
-			newName += binaryname;
+			newName += fileid;
 			getLogger().warn( "decrypted: " + streamName  + " -> " + newName );
 
 			return newName;
@@ -298,7 +297,7 @@ public class EncryptedStreamNameModule extends ModuleBase
 		{
 			throw new Exception(
 				"Error building stream name: " + newName + ", " + objid + ", "
-						 + filesetid + ", " + binaryname + ", " + fileid
+						 + filesetid + ", " + fileid
 			);
 		}
 	}

--- a/src/test/java/edu/ucsd/library/dams/util/EncryptedStreamNameModuleTest.java
+++ b/src/test/java/edu/ucsd/library/dams/util/EncryptedStreamNameModuleTest.java
@@ -34,12 +34,12 @@ public class EncryptedStreamNameModuleTest  {
 
 	@Test
 	public void testDecrypt() throws Exception {
-		String encryptedtext = "kf8ih30qyrw39rpb,wSTL7GcDUZd1ic1qLwKA3ubn9Amh4rbr5NQymDdDvwT-GZW-KkzsLJfz4dd8KzwFHG5xdrqslOyaY7_m2Y60wfkJNDsVw2RbpSCxOCsX6FA=";
+		String encryptedtext = "23pzfwgc4l4qquu6,dX1BCnOu8ol9nrabXi5Vufgjv_K4YOIZLYuc-ozV3AWk6oHOGzIBfgsWRIX0kOlQ";
 		String[] parts = encryptedtext.split(",");
 		String nonce = parts[0];
 		String ciphertext = parts[1];
 		String plaintext = module.decrypt( nonce, ciphertext );
-		String expected = "3j333268h d504rk75p 34cddd4138eeb3686bdb095b9a26ac077919b0f0 mp3 127.0.0.1";
+		String expected = "3j333268h d504rk75p p-mp3.mp3 127.0.0.1";
 		Assert.assertEquals("Descripted text need to be matched", expected, plaintext);
 	}
 }


### PR DESCRIPTION
Fixes #5 ; ref #5

- Remove parameter binaryname (binary file name) for Fedora file reference
- Change the streaming filename to lookup the A/V file from the derivatives filestore
- Update unique test to decrypt the encrypted variables